### PR TITLE
Missing semicolon on scope.onready.js

### DIFF
--- a/src/scope.onready.js
+++ b/src/scope.onready.js
@@ -47,7 +47,7 @@ angular.module('Scope.onReady', []).run(['$rootScope', '$injector', function($ro
     }
     this[successKey] = null;
     this[readyKey] = false;
-  }
+  };
 
   //this is used within each directive
   $rootScope.$whenReady = function(success, fail) {


### PR DESCRIPTION
This missing semicolon are broking IE8.
